### PR TITLE
Zeige Fehlertyp

### DIFF
--- a/StringCommandGUI/StringGUI.java
+++ b/StringCommandGUI/StringGUI.java
@@ -166,7 +166,7 @@ public class StringGUI extends JFrame {
             Method m = StringBefehle.class.getMethod(command, String.class);
             out = (String) m.invoke(null, in);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            out = String.format("FEHLER beim Methodenaufruf von '%s'", command);
+            out = String.format("FEHLER beim Methodenaufruf von '%s'\nFehlerytp: " + e.getCause(), command);
         }
 
         taOutput.setText(out);


### PR DESCRIPTION
Zeigt den Fehlertyp in einer neuen Zeile in `taOutput` durch ein unwrappen von `InvocationTargetException`. Hilft den SuS beim Debuggen und übt sie im Umgang mit Fehlermeldungen.

Alternativ könnte man auch den Stacktrace ausgeben, allerdings ist dieser durch `java.awt` verkompliziert und kann abschreckend wirken. 