### PR TITLE
Fix for private functions and Lambda expressions

### DIFF
--- a/StringCommandGUI/StringGUI.java
+++ b/StringCommandGUI/StringGUI.java
@@ -6,6 +6,7 @@ import java.awt.Font;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Objects;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -145,8 +146,7 @@ public class StringGUI extends JFrame {
             }
         }
 
-        Arrays.sort(methods);
-        return methods;
+        return Arrays.stream(methods).filter(Objects::nonNull).sorted().toArray(String[]::new);
 
     }
 

--- a/StringCommandGUI/StringGUI.java
+++ b/StringCommandGUI/StringGUI.java
@@ -166,7 +166,7 @@ public class StringGUI extends JFrame {
             Method m = StringBefehle.class.getMethod(command, String.class);
             out = (String) m.invoke(null, in);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            out = String.format("FEHLER beim Methodenaufruf von '%s'\nFehlerytp: " + e.getCause(), command);
+            out = String.format("FEHLER beim Methodenaufruf von '%s'\nFehlertyp: " + e.getCause(), command);
         }
 
         taOutput.setText(out);


### PR DESCRIPTION
Fixes #2.
`getDeclaredMethods()` returns inner lambda functions which are sorted out in the loop, resulting in null references in `methods`.

![image](https://user-images.githubusercontent.com/65015656/115553506-c69aae80-a2ad-11eb-8ed6-76830b540fa0.png)
